### PR TITLE
Update base_model.py

### DIFF
--- a/models/base_model.py
+++ b/models/base_model.py
@@ -27,7 +27,7 @@ def build_model(inputs, n_his, Ks, Kt, blocks, keep_prob):
     # ST-Block
     for i, channels in enumerate(blocks):
         x = st_conv_block(x, Ks, Kt, channels, i, keep_prob, act_func='GLU')
-        Ko -= 2 * (Ks - 1)
+        Ko -= 2 * (Kt - 1)
 
     # Output Layer
     if Ko > 1:


### PR DESCRIPTION
Ko -= 2 * (Kt - 1) instead of Ko -= 2 * (Ks - 1), each ST-GCN block should shorten the length of sequences by2 *(Kt-1)